### PR TITLE
Fix an error in SmartModelForm's validation exclusions

### DIFF
--- a/is_core/forms/models.py
+++ b/is_core/forms/models.py
@@ -214,7 +214,7 @@ class SmartModelForm(SmartFormMixin, RestModelForm, metaclass=SmartModelFormMeta
         for f in self.instance._meta.fields:
             field = f.name
             if field in self.readonly_fields and field not in exclude:
-                exclude.append(field)
+                exclude.add(field)
         return exclude
 
 


### PR DESCRIPTION
The parent method from Django returns a `set` instead of a `list` as before and therefore it's necessary to use methods applicable to this type.