### PR TITLE
Fix: AndPermission can't return self for & operator

### DIFF
--- a/is_core/auth/permissions.py
+++ b/is_core/auth/permissions.py
@@ -80,9 +80,7 @@ class AndPermission(OperatorPermission):
 
     def __and__(self, other):
         assert isinstance(other, BasePermission), 'Only permission instances can be joined'
-
-        self.add(other)
-        return self
+        return AndPermission(self, other)
 
 
 class OrPermission(OperatorPermission):


### PR DESCRIPTION
Returning self in & is not intended usage for the operator. The operator is meant to be used as:

```
perm = Perm1() & Perm2() & Perm3()
```

However, if we wanted to reuse permissions above we may want to use:

```
perm_other = perm & Perm3()
```

Before this commit such an operation would not only alter `perm_other` but also `perm`. Moreover, `perm_other` would be identical to `perm`, meaning `perm is perm_other`.